### PR TITLE
Add a debug config (runs fast)

### DIFF
--- a/model_configs/dnase_only_train_debug.yml
+++ b/model_configs/dnase_only_train_debug.yml
@@ -1,0 +1,57 @@
+---
+ops: [train, evaluate]
+lr: 0.00001
+model: {
+    path: src/deep_ct_model.py,
+    class: DeepCT,
+    class_args: {
+        sequence_length: 1000,
+        n_cell_types: 125,
+        sequence_embedding_length: 128,
+        cell_type_embedding_length: 32,
+        final_embedding_length: 128,
+        n_genomic_features: 1,
+    },
+    non_strand_specific: mean
+}
+sampler: !obj:src.samplers.deep_ct_sampler.IntervalsSampler {
+    reference_sequence: !obj:selene_sdk.sequences.Genome {
+        input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+        blacklist_regions: hg19
+    },
+    features: !obj:selene_sdk.utils.load_features_list {
+        input_path: /mnt/datasets/DeepCT/dnase_features/distinct_features.txt
+    },
+    target_path: /mnt/datasets/DeepCT/dnase_features/sorted_deepsea_data.bed.gz,
+    intervals_path: /mnt/datasets/DeepCT/dnase_features/TF_intervals.txt,
+    test_holdout: [chr8, chr9],
+    validation_holdout: [chr6, chr7],
+    seed: 127,
+    sequence_length: 1000,
+    center_bin_to_predict: 200,
+    feature_thresholds: 0.5,
+    save_datasets: ["train", "validate", "test"],
+    mode: train,
+}
+train_model: !obj:selene_sdk.TrainModel {
+    batch_size: 64,
+    max_steps: 50,
+    report_stats_every_n_steps: 10,
+    report_gt_feature_n_positives: 0,
+    n_validation_samples: 100,
+    n_test_samples: 200,
+    use_cuda: True,
+    data_parallel: False,
+    logging_verbosity: 2,
+    metrics: {
+        accuracy: !import src.metrics.accuracy_score,
+        f1: !import src.metrics.f1_score,
+        precision: !import src.metrics.precision_score,
+        recall: !import src.metrics.recall_score,
+        roc_auc: !import sklearn.metrics.roc_auc_score,
+    },
+}
+output_dir: DeepCT_outputs/debug
+random_seed: 1447
+create_subdirectory: True
+...


### PR DESCRIPTION
# Description

Added a config to simply test the train workflow.

```
    batch_size: 64,
    max_steps: 50,
    report_stats_every_n_steps: 10,
    n_validation_samples: 100,
    n_test_samples: 200,
```


# How Has This Been Tested?

Ran it with
```bash
CUDA_VISIBLE_DEVICES=3 python -u ~/selene/selene_sdk/cli.py model_configs/dnase_only_train_debug.yml 
```

