### PR TITLE
Add a model and config to train DeepCT like DeepSEA

### DIFF
--- a/model_configs/dnase_only_dds_style_train.yml
+++ b/model_configs/dnase_only_dds_style_train.yml
@@ -1,0 +1,68 @@
+---
+ops: [train, evaluate]
+lr: 0.008
+model: {
+    path: src/dnase_only_model.py,
+    class: DeepCT,
+    class_args: {
+        sequence_length: 1000,
+        n_cell_types: 125,
+        sequence_embedding_length: 128,
+        cell_type_embedding_length: 32,
+        final_embedding_length: 256,
+        n_genomic_features: 1,
+    },
+    non_strand_specific: mean
+}
+sampler: !obj:selene_sdk.samplers.MultiFileSampler {
+    train_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/train_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    validate_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/validate_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    test_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/test_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    features: !obj:selene_sdk.utils.load_features_list {
+        input_path: /mnt/datasets/DeepCT/dnase_features/distinct_features.txt
+    },
+}
+train_model: !obj:selene_sdk.TrainModel {
+    batch_size: 8,
+    max_steps: 960000,
+    report_stats_every_n_steps: 5000,
+    report_gt_feature_n_positives: 0,
+    n_validation_samples: 16000,
+    n_test_samples: 640000,
+    use_cuda: True,
+    data_parallel: True,
+    logging_verbosity: 2,
+    metrics: {
+        accuracy: !import src.metrics.accuracy_score,
+        average_precision: !import sklearn.metrics.average_precision_score,
+        f1: !import src.metrics.f1_score,
+        precision: !import src.metrics.precision_score,
+        recall: !import src.metrics.recall_score,
+        roc_auc: !import sklearn.metrics.roc_auc_score,
+    },
+}
+output_dir: DeepCT_outputs/deep_ct_v2
+random_seed: 1447
+create_subdirectory: True
+...

--- a/model_configs/dnase_only_dds_style_train_debug.yml
+++ b/model_configs/dnase_only_dds_style_train_debug.yml
@@ -1,0 +1,68 @@
+---
+ops: [train, evaluate]
+lr: 0.00001
+model: {
+    path: src/dnase_only_model.py,
+    class: DeepCT,
+    class_args: {
+        sequence_length: 1000,
+        n_cell_types: 125,
+        sequence_embedding_length: 128,
+        cell_type_embedding_length: 32,
+        final_embedding_length: 512,
+        n_genomic_features: 1,
+    },
+    non_strand_specific: mean
+}
+sampler: !obj:selene_sdk.samplers.MultiFileSampler {
+    train_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/train_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    validate_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/validate_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    test_sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+        filepath: /mnt/datasets/DeepCT/dnase_features/test_data.bed,
+        reference_sequence: !obj:selene_sdk.sequences.Genome {
+            input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+            blacklist_regions: hg19
+        },
+        n_cell_types: 125,
+    },
+    features: !obj:selene_sdk.utils.load_features_list {
+        input_path: /mnt/datasets/DeepCT/dnase_features/distinct_features.txt
+    },
+}
+train_model: !obj:selene_sdk.TrainModel {
+    batch_size: 2,
+    max_steps: 50,
+    report_stats_every_n_steps: 10,
+    report_gt_feature_n_positives: 0,
+    n_validation_samples: 100,
+    n_test_samples: 100,
+    use_cuda: True,
+    data_parallel: True,
+    logging_verbosity: 2,
+    metrics: {
+        accuracy: !import src.metrics.accuracy_score,
+        average_precision: !import sklearn.metrics.average_precision_score,
+        f1: !import src.metrics.f1_score,
+        precision: !import src.metrics.precision_score,
+        recall: !import src.metrics.recall_score,
+        roc_auc: !import sklearn.metrics.roc_auc_score,
+    },
+}
+output_dir: DeepCT_outputs/debug_v2
+random_seed: 1447
+create_subdirectory: True
+...

--- a/src/dnase_only_model.py
+++ b/src/dnase_only_model.py
@@ -1,0 +1,166 @@
+"""
+DeepCT architecture (TODO: Add our names).
+"""
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.tensorboard import SummaryWriter
+
+
+class DeepCT(nn.Module):
+    def __init__(
+        self,
+        sequence_length,
+        n_cell_types,
+        sequence_embedding_length,
+        cell_type_embedding_length,
+        final_embedding_length,
+        n_genomic_features,
+    ):
+        """
+        Based on a DeepSEA architecture (see https://github.com/FunctionLab/selene/blob/0.4.8/models/deepsea.py)
+
+        Parameters
+        ----------
+        sequence_length : int
+            Length of input sequence.
+        n_cell_types : int
+            Number of cell types.
+        sequence_embedding_length : int
+        cell_type_embedding_length : int
+        final_embedding_length : int
+        n_genomic_features : int
+            Number of target features.
+        """
+        super().__init__()
+
+        self._n_cell_types = n_cell_types
+
+        conv_kernel_size = 8
+        pool_kernel_size = 4
+
+        self.conv_net = nn.Sequential(
+            nn.Conv1d(4, 320, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(320, 320, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.MaxPool1d(kernel_size=pool_kernel_size, stride=pool_kernel_size),
+            nn.BatchNorm1d(320),
+            nn.Conv1d(320, 480, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(480, 480, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.MaxPool1d(kernel_size=pool_kernel_size, stride=pool_kernel_size),
+            nn.BatchNorm1d(480),
+            nn.Dropout(p=0.2),
+            nn.Conv1d(480, 960, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(960, 960, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(960),
+            nn.Dropout(p=0.2),
+        )
+
+        reduce_by = 2 * (conv_kernel_size - 1)
+        pool_kernel_size = float(pool_kernel_size)
+        self._n_channels = int(
+            np.floor(
+                (np.floor((sequence_length - reduce_by) / pool_kernel_size) - reduce_by)
+                / pool_kernel_size
+            )
+            - reduce_by
+        )
+
+        self.sequence_net = nn.Sequential(
+            nn.Linear(960 * self._n_channels, sequence_embedding_length),
+            nn.ReLU(inplace=True),
+        )
+
+        self.cell_type_net = nn.Sequential(
+            nn.Linear(self._n_cell_types, cell_type_embedding_length),
+        )
+
+        self.classifier = nn.Sequential(
+            nn.Linear(
+                sequence_embedding_length + cell_type_embedding_length,
+                final_embedding_length,
+            ),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(final_embedding_length),
+            nn.Linear(final_embedding_length, n_genomic_features),
+            nn.Sigmoid(),
+        )
+
+    def log_cell_type_embeddings_to_tensorboard(self, cell_type_labels, output_dir):
+        writer = SummaryWriter(output_dir)
+        writer.add_embedding(
+            self.cell_type_net[0].weight.transpose(0, 1), cell_type_labels
+        )
+        writer.flush()
+        writer.close()
+
+    def forward(self, x):
+        """Forward propagation of a batch.
+
+        Parameters:
+        -----------
+        x : torch.Tensor
+            A batch of encoded sequences.
+        """
+        batch_size = x.size(0)
+
+        cell_type_one_hots = torch.eye(self._n_cell_types).to(x.device)
+
+        sequence_out = self.conv_net(x)
+        reshaped_sequence_out = sequence_out.view(
+            sequence_out.size(0), 960 * self._n_channels
+        )
+
+        # Repeat each sequence embedding to fit cell type embeddings.
+        # E.g., with 2 cell types, [seq0_emb, seq1_emb, seq2_emb] becomes
+        # [seq0_emb, seq0_emb, seq1_emb, seq1_emb, seq2_emb, seq2_emb]
+        sequence_embedding = self.sequence_net(reshaped_sequence_out).repeat_interleave(
+            repeats=self._n_cell_types, dim=0
+        )
+
+        # Repeat cell type embeddings to fit sequence embeddings.
+        # E.g., with batch size of 3, 2 cell types, and [ct0_emb, ct1_emb] cell type
+        # embeddings, the embeddings will be converted to
+        # [ct0_emb, ct1_emb, ct0_emb, ct1_emb, ct0_emb, ct1_emb].
+        cell_type_embeddings = self.cell_type_net(cell_type_one_hots).repeat(
+            batch_size, 1
+        )
+
+        # Note that 0's dimention of sequence and cell type embeddings are now equal!
+
+        sequence_and_cell_type_embeddings = torch.cat(
+            (sequence_embedding, cell_type_embeddings), 1
+        )
+
+        predict = self.classifier(sequence_and_cell_type_embeddings).view(
+            batch_size, self._n_cell_types
+        )
+        return predict
+
+
+def criterion():
+    """
+    The criterion the model aims to minimize.
+    """
+    # TODO: Update the criterion to evaluate only features available for the provided
+    # cell type.
+    return nn.BCELoss()
+
+
+def get_optimizer(lr):
+    """
+    The optimizer and the parameters with which to initialize the optimizer.
+    At a later time, we initialize the optimizer by also passing in the model
+    parameters (`model.parameters()`). We cannot initialize the optimizer
+    until the model has been initialized.
+    """
+    # Option 1:
+    return (torch.optim.SGD, {"lr": lr, "weight_decay": 1e-6, "momentum": 0.9})
+
+    # Option 2:
+    #  return (torch.optim.Adam, {"lr": lr})


### PR DESCRIPTION
# Description

Added a model that utilizes given sequence `n_cell_types` times.

So the
- input shape is `(batch_size, 4, sequence_length)`;
- target shape is `(batch_size, n_cell_types)`.
- forward output shape is `(batch_size, n_cell_types)`

and `forward(x)` does compute embeddings for all cell types. Then it combines these embeddings with a sequence embedding (which can be computed just once).

# How Has This Been Tested?

Ran it locally and added a debug config with a small number of samples.

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
