### PR TITLE
Use same validation setup in DeeperDeepSEA as for DeepCT

### DIFF
--- a/model_configs/deeper_deep_sea_benchmark.yml
+++ b/model_configs/deeper_deep_sea_benchmark.yml
@@ -9,34 +9,25 @@ model: {
     },
     non_strand_specific: mean
 }
-sampler: !obj:selene_sdk.samplers.IntervalsSampler {
+sampler: !obj:src.samplers.dnase_file_sampler.DNaseFileSampler {
+    filepath: /mnt/datasets/DeepCT/dnase_features/test_data.bed,
     reference_sequence: !obj:selene_sdk.sequences.Genome {
         input_path: /mnt/datasets/DeepCT/male.hg19.fasta,
         blacklist_regions: hg19
     },
-    features: !obj:selene_sdk.utils.load_features_list {
-        input_path: /mnt/datasets/DeepCT/dnase_features/distinct_features.txt
-    },
-    target_path: /mnt/datasets/DeepCT/dnase_features/sorted_deepsea_data.bed.gz,
-    intervals_path: /mnt/datasets/DeepCT/dnase_features/TF_intervals.txt,
-    test_holdout: [chr8, chr9],
-    validation_holdout: [chr6, chr7],
-    seed: 127,
-    sequence_length: 1000,
-    center_bin_to_predict: 200,
-    feature_thresholds: 0.5,
+    n_cell_types: 125,
 }
-evaluate_model: !obj:selene_sdk.EvaluateModel {
+evaluate_model: !obj:src.evaluation.evaluate_model.EvaluateModel {
     features:  !obj:selene_sdk.utils.load_features_list {
         input_path: /mnt/datasets/DeepCT/dnase_features/distinct_features.txt,
     },
-    n_test_samples: 9000,
+    n_test_samples: 64000,
     trained_model_path: /home/arlapin/DeepCT/DeepCT_outputs/DDS_trained_on_DNase/best_model.pth.tar,
-    batch_size: 1024,
+    batch_size: 1000,
     report_gt_feature_n_positives: 0,
     use_cuda: True,
     data_parallel: True,
-    output_dir: DeepCT_outputs/DDS_evaluation,
+    log_cell_type_embeddings_to_tensorboard: False,
     metrics: {
         accuracy: !import src.metrics.accuracy_score,
         average_precision: !import sklearn.metrics.average_precision_score,

--- a/src/evaluation/evaluate_model.py
+++ b/src/evaluation/evaluate_model.py
@@ -58,6 +58,10 @@ class EvaluateModel(object):
     data_parallel : bool, optional
         Default is `False`. Specify whether multiple GPUs are available
         for torch to use during training.
+    log_cell_type_embeddings_to_tensorboard : bool, optional
+        Default is `True`. Wether to publish cell type embeddings to tensorboard.
+        NOTE: If True, a model should have `log_cell_type_embeddings_to_tensorboard`
+        method.
 
     Attributes
     ----------
@@ -86,6 +90,7 @@ class EvaluateModel(object):
         report_gt_feature_n_positives=10,
         use_cuda=False,
         data_parallel=False,
+        log_cell_type_embeddings_to_tensorboard=True,
         metrics=dict(roc_auc=roc_auc_score, average_precision=average_precision_score),
     ):
         self.n_test_samples = n_test_samples
@@ -114,9 +119,11 @@ class EvaluateModel(object):
             self.model = load_model_from_state_dict(trained_model["state_dict"], model)
         else:
             self.model = load_model_from_state_dict(trained_model, model)
-        self.model.model.log_cell_type_embeddings_to_tensorboard(
-            self.features, self.output_dir
-        )
+
+        if log_cell_type_embeddings_to_tensorboard:
+            self.model.model.log_cell_type_embeddings_to_tensorboard(
+                self.features, self.output_dir
+            )
 
         self.model.eval()
         if data_parallel:


### PR DESCRIPTION
# Description

Make it use the same samples, sampler, and evaluation script


# How Has This Been Tested?

I ran it and it worked.

```
2021-03-31 12:33:08,931 - test loss: 0.20369701832532883                                                                                          
2021-03-31 12:33:08,931 - test accuracy: 0.923821125                                                                                              
2021-03-31 12:33:08,931 - test average_precision: 0.5210151755128877                                                                              
2021-03-31 12:33:08,931 - test f1: 0.42590804158752493                                                                                            
2021-03-31 12:33:08,931 - test precision: 0.664078018816746                                                                                       
2021-03-31 12:33:08,931 - test recall: 0.3184499541006571                                                                                         
2021-03-31 12:33:08,931 - test roc_auc: 0.8828133289749313                                                                                                                                               
```

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
