### PR TITLE
Add dataset training on all cell types at once

### DIFF
--- a/model_configs/encode_dnase_multi_ct_train.yml
+++ b/model_configs/encode_dnase_multi_ct_train.yml
@@ -1,0 +1,62 @@
+---
+ops: [train, evaluate]
+lr: 0.0001
+model: {
+    path: src/deepct_model_multi_ct.py,
+    class: DeepCT,
+    class_args: {
+        sequence_length: 1000,
+        n_cell_types: 125,
+        sequence_embedding_length: 256,
+        cell_type_embedding_length: 32,
+        final_embedding_length: 256,
+        n_genomic_features: 1,
+    }
+}
+dataset: {
+    path: src/dataset.py,
+    class: EncodeDataset,
+    sampler_class: LargeRandomSampler,
+
+    distinct_features_path: /mnt/datasets/DeepCT/dataset_data/dnase/distinct_features.txt,
+    target_features_path: /mnt/datasets/DeepCT/dataset_data/dnase/target_features.txt,
+    sampling_intervals_path: /mnt/datasets/DeepCT/dataset_data/dnase/target_intervals.bed,
+    test_holdout: [chr8, chr9],
+    validation_holdout: [chr6, chr7],
+    
+    dataset_args: {
+        reference_sequence_path: /mnt/datasets/DeepCT/male.hg19.fasta,
+        target_path: /mnt/datasets/DeepCT/dataset_data/dnase/sorted_data.bed.gz,
+        cell_wise: True,
+        multi_ct_target: True,
+        sequence_length: 1000,
+        center_bin_to_predict: 200,
+        feature_thresholds: 0.5,
+    },
+    loader_args: {
+        batch_size: 128,
+        num_workers: 16,
+    },
+}
+train_model: !obj:src.train.train_encode_dataset.TrainEncodeDatasetModel {
+    n_epochs: 100,
+    report_stats_every_n_steps: 2000,
+    save_checkpoint_every_n_steps: 2000,
+    report_gt_feature_n_positives: 10,
+    device: 'cuda:3',
+    data_parallel: False,
+    logging_verbosity: 2,
+    metrics: {
+        accuracy: !import src.metrics.accuracy_score,
+        average_precision: !import sklearn.metrics.average_precision_score,
+        f1: !import src.metrics.f1_score,
+        precision: !import src.metrics.precision_score,
+        recall: !import src.metrics.recall_score,
+        roc_auc: !import sklearn.metrics.roc_auc_score,
+    },
+}
+output_dir: DeepCT_outputs/encode/tst
+
+random_seed: 1447
+create_subdirectory: True
+...

--- a/src/deepct_model_multi_ct.py
+++ b/src/deepct_model_multi_ct.py
@@ -1,0 +1,182 @@
+"""
+DeepCT architecture without Sigmoid layer 
+for multiple cell type per position computation at once (TODO: Add our names).
+"""
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.tensorboard import SummaryWriter
+
+
+class DeepCT(nn.Module):
+    def __init__(
+        self,
+        sequence_length,
+        n_cell_types,
+        sequence_embedding_length,
+        cell_type_embedding_length,
+        final_embedding_length,
+        n_genomic_features,
+    ):
+        """
+        Based on a DeepSEA architecture (see https://github.com/FunctionLab/selene/blob/0.4.8/models/deepsea.py)
+
+        Parameters
+        ----------
+        sequence_length : int
+            Length of input sequence.
+        n_cell_types : int
+            Number of cell types.
+        sequence_embedding_length : int
+        cell_type_embedding_length : int
+        final_embedding_length : int
+        n_genomic_features : int
+            Number of target features.
+        """
+        super(DeepCT, self).__init__()
+        self._n_cell_types = n_cell_types
+        conv_kernel_size = 8
+        pool_kernel_size = 4
+
+        self.conv_net = nn.Sequential(
+            nn.Conv1d(4, 320, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(320, 320, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.MaxPool1d(kernel_size=pool_kernel_size, stride=pool_kernel_size),
+            nn.BatchNorm1d(320),
+            nn.Conv1d(320, 480, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(480, 480, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.MaxPool1d(kernel_size=pool_kernel_size, stride=pool_kernel_size),
+            nn.BatchNorm1d(480),
+            nn.Dropout(p=0.2),
+            nn.Conv1d(480, 960, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.Conv1d(960, 960, kernel_size=conv_kernel_size),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(960),
+            nn.Dropout(p=0.2),
+        )
+
+        reduce_by = 2 * (conv_kernel_size - 1)
+        pool_kernel_size = float(pool_kernel_size)
+        self._n_channels = int(
+            np.floor(
+                (np.floor((sequence_length - reduce_by) / pool_kernel_size) - reduce_by)
+                / pool_kernel_size
+            )
+            - reduce_by
+        )
+
+        self.sequence_net = nn.Sequential(
+            nn.Linear(960 * self._n_channels, sequence_embedding_length),
+            nn.ReLU(inplace=True),
+        )
+
+        self.cell_type_net = nn.Sequential(
+            nn.Linear(n_cell_types, cell_type_embedding_length),
+        )
+
+        self.classifier = nn.Sequential(
+            nn.Linear(
+                sequence_embedding_length + cell_type_embedding_length,
+                final_embedding_length,
+            ),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(final_embedding_length),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(final_embedding_length),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.Linear(final_embedding_length, final_embedding_length),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm1d(final_embedding_length),
+            nn.Linear(final_embedding_length, n_genomic_features),
+            # sigmoid turned off for loss numerical stability
+            # nn.Sigmoid(),
+        )
+
+    def log_cell_type_embeddings_to_tensorboard(self, cell_type_labels, output_dir):
+        writer = SummaryWriter(output_dir)
+        writer.add_embedding(
+            self.cell_type_net[0].weight.transpose(0, 1), cell_type_labels
+        )
+        writer.flush()
+        writer.close()
+
+    def forward(self, sequence_batch, cell_type_batch):
+        """Forward propagation of a batch.
+
+        Parameters:
+        -----------
+        sequence_batch : torch.Tensor
+            A batch of encoded sequences.
+        cell_type_batch: torch.Tensor
+            A batch of one-hot cell type encodings.
+
+        """
+        batch_size = sequence_batch.size(0)
+
+        cell_type_one_hots = torch.eye(self._n_cell_types).to(sequence_batch.device)
+
+        sequence_out = self.conv_net(sequence_batch)
+        reshaped_sequence_out = sequence_out.view(
+            sequence_out.size(0), 960 * self._n_channels
+        )
+        # Repeat each sequence embedding to fit cell type embeddings.
+        # E.g., with 2 cell types, [seq0_emb, seq1_emb, seq2_emb] becomes
+        # [seq0_emb, seq0_emb, seq1_emb, seq1_emb, seq2_emb, seq2_emb]
+        sequence_embedding = self.sequence_net(reshaped_sequence_out).repeat_interleave(
+            repeats=self._n_cell_types, dim=0
+        )
+
+        # Repeat cell type embeddings to fit sequence embeddings.
+        # E.g., with batch size of 3, 2 cell types, and [ct0_emb, ct1_emb] cell type
+        # embeddings, the embeddings will be converted to
+        # [ct0_emb, ct1_emb, ct0_emb, ct1_emb, ct0_emb, ct1_emb].
+        cell_type_embeddings = self.cell_type_net(cell_type_one_hots).repeat(
+            batch_size, 1
+        )
+        sequence_and_cell_type_embeddings = torch.cat(
+            (sequence_embedding, cell_type_embeddings), 1
+        )
+
+        predict = self.classifier(sequence_and_cell_type_embeddings).view(
+            batch_size, self._n_cell_types, -1
+        )
+        return predict
+
+
+def criterion(**loss_config):
+    """
+    The criterion the model aims to minimize.
+    """
+    if "pos_weights_path" in loss_config:
+        with open(loss_config["pos_weights_path"]) as f:
+            pos_weight = list(map(float, f.readlines()))
+        pos_weight = torch.tensor(pos_weight)
+        return nn.BCEWithLogitsLoss(pos_weight)
+    return nn.BCEWithLogitsLoss()
+
+
+def get_optimizer(lr):
+    """
+    The optimizer and the parameters with which to initialize the optimizer.
+    At a later time, we initialize the optimizer by also passing in the model
+    parameters (`model.parameters()`). We cannot initialize the optimizer
+    until the model has been initialized.
+    """
+    # Option 1:
+    # return (torch.optim.SGD, {"lr": lr, "weight_decay": 1e-6, "momentum": 0.9})
+
+    # Option 2:
+    return (torch.optim.Adam, {"lr": lr})


### PR DESCRIPTION
# Description

Adds all the necessary files (model and config file to use) and dataset option to enable training position-wise for all cell types at once


# How Has This Been Tested?

Ran `python -u ~/selene/selene_sdk/cli.py model_configs/encode_dnase_multi_ct_train.yml` with `multi_ct_target` option enabled

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
