### PR TITLE
Add transforms as a separate module

### DIFF
--- a/model_configs/encode_dnase_multi_ct_train.yml
+++ b/model_configs/encode_dnase_multi_ct_train.yml
@@ -37,6 +37,14 @@ dataset: {
         batch_size: 128,
         num_workers: 16,
     },
+    train_transform: !obj:torchvision.transforms.Compose {
+        transforms: [
+            !obj:src.transforms.PermuteSequenceChannels {},
+            !obj:src.transforms.RandomReverseStrand {
+                p: 0.5,
+            }
+        ],
+    }
 }
 train_model: !obj:src.train.train_encode_dataset.TrainEncodeDatasetModel {
     n_epochs: 100,

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -5,21 +5,9 @@ import torch
 from selene_sdk.sequences import Genome
 from selene_sdk.targets import GenomicFeatures
 
+from src.transforms import PermuteSequenceChannels
+
 _FEATURE_NOT_PRESENT = -1
-
-
-class PermuteSequenceChannels:
-    """
-    Permute channels of retrieved encoded DNA sequence.
-
-    Permutes axes of `np.array` of shape `(sequence_length, alphabet_size)` to
-    obtain `np.array` of shape `(alphabet_size, sequence_length)`
-    """
-
-    def __call__(self, *sample):
-        seq = sample[0]
-        perm_seq = np.transpose(seq)
-        return (perm_seq, *sample[1:])
 
 
 class EncodeDataset(torch.utils.data.Dataset):
@@ -193,8 +181,8 @@ class EncodeDataset(torch.utils.data.Dataset):
     def __getitem__(self, idx):
         chrom, pos, cell_type_idx = self._get_chrom_pos_cell_by_idx(idx)
         retrieved_sample = self._retrieve(chrom, pos, cell_type_idx)
-        if self.transform:
-            retrieved_sample = self.transform(*retrieved_sample)
+        if self.transform is not None:
+            retrieved_sample = self.transform(retrieved_sample)
         if self.cell_wise:
             return retrieved_sample
         retrieved_seq = retrieved_sample[0]

--- a/src/transforms.py
+++ b/src/transforms.py
@@ -1,0 +1,46 @@
+import numpy as np
+import torch
+
+
+class PermuteSequenceChannels(torch.nn.Module):
+    """
+    Permute channels of retrieved encoded DNA sequence.
+
+    Permutes axes of `np.array` of shape `(sequence_length, alphabet_size)` to
+    obtain `np.array` of shape `(alphabet_size, sequence_length)`
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, sample):
+        seq = sample[0]
+        perm_seq = np.transpose(seq)
+        return (perm_seq, *sample[1:])
+
+
+class RandomReverseStrand(torch.nn.Module):
+    """
+    Randomly change the strand of retrieved encoded DNA sequence.
+    !!! Only works if DNA letter encodings of complementary letters are mirrors
+    of each other, e.g. if `[1, 0, 0, 0]` is an encoding of letter A, letter T should
+    have encoding `[0, 0, 0, 1]`. Selene letter encodings are like this by default.
+
+    Randomly flips the contents of encoded sequence along all available axes to
+    obtain a sequence identical to the one taken from a different DNA strand
+
+    Parameters
+    ----------
+    p:  float
+        Probability that the strand should be reversed.
+    """
+
+    def __init__(self, p=0.5):
+        super().__init__()
+        self.p = p
+
+    def forward(self, sample):
+        seq = sample[0]
+        if torch.rand(1) < self.p:
+            return (np.flip(seq).copy(), *sample[1:])
+        return sample


### PR DESCRIPTION
# Description

This PR introduces a separate module for sample augmentations `src.transforms` and updates the dataset class accordingly. The model config is changed to serve as a use-case example.

# How Has This Been Tested?

Ran `python -u ~/selene/selene_sdk/cli.py model_configs/encode_dnase_multi_ct_train.yml`.

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
