### PR TITLE
Add scheduler information to config

### DIFF
--- a/model_configs/encode_dnase_multi_ct_train.yml
+++ b/model_configs/encode_dnase_multi_ct_train.yml
@@ -1,6 +1,12 @@
 ---
 ops: [train, evaluate]
 lr: 0.0001
+lr_scheduler: {
+    class: !import torch.optim.lr_scheduler.CosineAnnealingLR,
+    class_args: {
+        T_max: 433900,
+    }
+}
 model: {
     path: src/deepct_model_multi_ct.py,
     class: DeepCT,
@@ -47,7 +53,7 @@ dataset: {
     }
 }
 train_model: !obj:src.train.train_encode_dataset.TrainEncodeDatasetModel {
-    n_epochs: 100,
+    n_epochs: 10,
     report_stats_every_n_steps: 2000,
     save_checkpoint_every_n_steps: 2000,
     report_gt_feature_n_positives: 10,


### PR DESCRIPTION
# Description

This PR adds LR scheduler information to dataset training config file and updates `TrainEncodeDatasetModel` accordingly.


# How Has This Been Tested?

Ran `python -u ~/selene/selene_sdk/cli.py model_configs/encode_dnase_multi_ct_train.yml`.

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
