### PR TITLE
fix model embeddings retrieval

### DIFF
--- a/src/deepct_model_multi_ct.py
+++ b/src/deepct_model_multi_ct.py
@@ -105,13 +105,25 @@ class DeepCT(nn.Module):
             # nn.Sigmoid(),
         )
 
+    def get_cell_type_embeddings(self):
+        """Retrieve cell type embeddings learned by the model."""
+        device = next(self.parameters()).device
+        with torch.no_grad():
+            all_cell_types = torch.eye(self._n_cell_types).to(device)
+            embeddings = self.cell_type_net(all_cell_types)
+        return embeddings.detach().cpu()
+
+    """
+    # Doesn't take linear layer bias into account
     def log_cell_type_embeddings_to_tensorboard(self, cell_type_labels, output_dir):
         writer = SummaryWriter(output_dir)
+
         writer.add_embedding(
             self.cell_type_net[0].weight.transpose(0, 1), cell_type_labels
         )
         writer.flush()
         writer.close()
+    """
 
     def forward(self, sequence_batch, cell_type_batch):
         """Forward propagation of a batch.


### PR DESCRIPTION
# Description

Changes cell type embedding retrieval from model by taking bias into account.


# How Has This Been Tested?

This was only tested locally by running `model.get_cell_type_embeddings()` on a `DeepCT` model

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
