### PR TITLE
Add sample masking for multi ct models to speed up evaluation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -6,8 +6,10 @@ from tqdm import tqdm
 
 # maximum size of targets stored in-memory for validation metrics computation,
 # value derived experimentally using data loader of size 2000, batch size 64,
-# 194 cell types, and 201 target features
-MAX_TOTAL_VAL_TARGET_SIZE = 2000 * 64 * 194 * 201
+# 194 cell types, and 201 targets
+# MAX_TOTAL_VAL_TARGET_SIZE = 2000 * 64 * 194 * 201
+# updated with data loader of size 500, batch size 128, 858 cell types, and 40 targets
+MAX_TOTAL_VAL_TARGET_SIZE = 500 * 128 * 858 * 40
 
 
 def expand_dims(x):


### PR DESCRIPTION
# Description

This PR changes validation batch reduction. As opposed to performing inference on all validation samples (and then saving a portion of those samples for evaluation), only relevant samples will be forwarded through the network.

Note: It could be just easier to make our validation set smaller by not sampling some dataset entries in the first place. However, since we're using `multi_ct_target=True` for faster training, one dataset sample refers to one specific location, and we would thus be throwing out entire locations from validation set, as opposed to throwing out some `(sequence, cell type)` pairs from validation, which is what this PR implements

# How Has This Been Tested?

Ran training and evaluation.

- [ ] I have added tests that prove my fix is effective or that my feature works


# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
