### PR TITLE
Multi-threshold metrics

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -13,9 +13,18 @@ def _to_binary(x: np.ndarray, threshold=0.5) -> np.ndarray:
 
 
 def binary_inputs(score_func):
+    """Wrapper function for input binarization using specified threshold(s)"""
+
     def binary_wrapper(y_true, y_pred, threshold=0.5, **kwargs):
-        binary_y_true = _to_binary(y_true, threshold)
-        binary_y_pred = _to_binary(y_pred, threshold)
+        if isinstance(threshold, float):
+            binary_y_true = _to_binary(y_true, threshold)
+            binary_y_pred = _to_binary(y_pred, threshold)
+        else:
+            mask = np.logical_or(y_pred > threshold[1], y_pred < threshold[0])
+            binarization_thresh = (threshold[0] + threshold[1]) / 2
+            y_pred = _to_binary(y_pred, binarization_thresh)
+            binary_y_true = y_true[mask]
+            binary_y_pred = y_pred[mask]
         return score_func(binary_y_true, binary_y_pred, **kwargs)
 
     return binary_wrapper


### PR DESCRIPTION
# Description

This PR allows for binary metrics to be calculated with either one or two thresholds. In case of two thresholds, input values lower than `lower_threshold` are binarized as 0, values higher than `upper_threshold` become 1, and the rest are dropped from metric calculation.

# How Has This Been Tested?

Successfully ran evaluation with both one and two thresholds

# Personal check-list (`[x]` to check)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
