### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.20.1
-torch==1.8.1
-torchvision==0.9.1
-git+git://github.com/AIRI-Institute/selene.git@arlapin/dev#egg=selene-sdk
+numpy==1.22.3
+torch==1.9.1
+torchvision==0.10.1
+git+ssh://github.com/AIRI-Institute/selene.git#egg=selene-sdk
 pyBigWig==0.3.17


### PR DESCRIPTION
# Description

1) use the master branch of Selene fork instead of an outdated dev one
2) update numpy as its C API has changed around 1.20, causing
   `ValueError: numpy.ndarray size changed, may indicate binary
   incompatibility. Expected 96 from C header, got 80 from PyObject`
3) update torch (was not mandatory but these versions do work)


# How Has This Been Tested?

```
mamba create -c conda-forge -n deepct python=3.8
conda activate deepct
pip install --no-cache-dir -r requirements.txt
python -m selene_sdk inference_config.yml
```
Previous version of requirements.txt resulted in the aforementioned error
